### PR TITLE
[feat] Slack 연동 갱신, 조회, 연동 해제 기능 추가

### DIFF
--- a/src/main/java/com/logilink/slack/controller/SlackController.java
+++ b/src/main/java/com/logilink/slack/controller/SlackController.java
@@ -1,7 +1,11 @@
 package com.logilink.slack.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.logilink.slack.common.BaseResponse;
 import com.logilink.slack.dto.request.SendMessageReq;
 import com.logilink.slack.dto.request.SlackLinkReq;
+import com.logilink.slack.dto.request.SlackUserLinkUpdateReq;
 import com.logilink.slack.dto.response.SlackUserLinkRes;
 import com.logilink.slack.service.SlackLinkService;
 import com.logilink.slack.service.SlackMessageService;
@@ -32,6 +37,25 @@ public class SlackController {
 		);
 
 		return ResponseEntity.ok(BaseResponse.success(link));
+	}
+
+	@GetMapping("/links/{userId}")
+	public ResponseEntity<SlackUserLinkRes> getLink(@PathVariable Long userId) {
+		SlackUserLinkRes res = slackLinkService.getLink(userId);
+		return ResponseEntity.ok(res);
+	}
+
+	@DeleteMapping("/links/{userId}")
+	public ResponseEntity<Long> unlink(@PathVariable Long userId) {
+		slackLinkService.unlink(userId);
+		return ResponseEntity.ok(userId);
+	}
+
+	@PutMapping("/links/{userId}")
+	public ResponseEntity<SlackUserLinkRes> update(@PathVariable Long userId,
+												   @Valid @RequestBody SlackUserLinkUpdateReq request) {
+		SlackUserLinkRes res = slackLinkService.update(userId, request);
+		return ResponseEntity.ok(res);
 	}
 
 	@PostMapping("/send")

--- a/src/main/java/com/logilink/slack/domain/repository/SlackUserLinkRepository.java
+++ b/src/main/java/com/logilink/slack/domain/repository/SlackUserLinkRepository.java
@@ -10,6 +10,10 @@ import com.logilink.slack.domain.entity.SlackUserLink;
 public interface SlackUserLinkRepository extends JpaRepository<SlackUserLink, UUID> {
 
 	Optional<SlackUserLink> findByUserId(Long userId);
+
 	Optional<SlackUserLink> findByEmail(String email);
+
 	boolean existsByEmail(String email);
+
+	Optional<SlackUserLink> findBySlackUserId(String slackUserId);
 }

--- a/src/main/java/com/logilink/slack/dto/request/SlackUserLinkUpdateReq.java
+++ b/src/main/java/com/logilink/slack/dto/request/SlackUserLinkUpdateReq.java
@@ -1,0 +1,8 @@
+package com.logilink.slack.dto.request;
+
+import jakarta.validation.constraints.Email;
+
+public record SlackUserLinkUpdateReq(
+	@Email
+	String email) {
+}

--- a/src/main/java/com/logilink/slack/dto/response/LookupByEmailRes.java
+++ b/src/main/java/com/logilink/slack/dto/response/LookupByEmailRes.java
@@ -12,5 +12,6 @@ public record LookupByEmailRes(
 	public record SlackUser(
 		String id,
 		String name
-	) {}
+	) {
+	}
 }

--- a/src/main/java/com/logilink/slack/service/SlackLinkService.java
+++ b/src/main/java/com/logilink/slack/service/SlackLinkService.java
@@ -7,10 +7,12 @@ import com.logilink.slack.client.SlackClient;
 import com.logilink.slack.common.exception.AppException;
 import com.logilink.slack.domain.entity.SlackUserLink;
 import com.logilink.slack.domain.repository.SlackUserLinkRepository;
+import com.logilink.slack.dto.request.SlackUserLinkUpdateReq;
 import com.logilink.slack.dto.response.LookupByEmailRes;
 import com.logilink.slack.dto.response.SlackUserLinkRes;
 import com.logilink.slack.exception.SlackErrorCode;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -32,9 +34,50 @@ public class SlackLinkService {
 			throw AppException.of(SlackErrorCode.SLACK_LOOKUP_FAILED);
 		}
 
-		SlackUserLink link = SlackUserLink.create(userId,email,res.user().id());
+		SlackUserLink link = SlackUserLink.create(userId, email, res.user().id());
 		SlackUserLink save = slackUserLinkRepository.save(link);
 
 		return SlackUserLinkRes.from(save);
+	}
+
+	@Transactional(readOnly = true)
+	public SlackUserLinkRes getLink(Long userId) {
+		SlackUserLink link = slackUserLinkRepository.findByUserId(userId)
+													.orElseThrow(
+														() -> AppException.of(SlackErrorCode.SLACK_USER_NOT_LINKED));
+		return SlackUserLinkRes.from(link);
+	}
+
+	@Transactional
+	public void unlink(Long userId) {
+		SlackUserLink link = slackUserLinkRepository.findByUserId(userId)
+													.orElseThrow(
+														() -> AppException.of(SlackErrorCode.SLACK_USER_NOT_LINKED));
+
+		// 이미 비활성화 상태일 경우 그냥 리턴
+		if (!link.isActive())
+			return;
+
+		link.deactivate();
+		slackUserLinkRepository.save(link);
+	}
+
+	public SlackUserLinkRes update(Long userId, @Valid SlackUserLinkUpdateReq request) {
+		SlackUserLink link = slackUserLinkRepository.findByUserId(userId)
+													.orElseThrow(
+														() -> AppException.of(SlackErrorCode.SLACK_USER_NOT_LINKED));
+
+		LookupByEmailRes res = slackClient.lookupByEmail(request.email());
+
+		// 새 slackUserId가 다른 사용자에게 이미 연결된 경우 방지
+		slackUserLinkRepository.findBySlackUserId(res.user().id()).ifPresent(existing -> {
+			if (!existing.getUserId().equals(userId) && existing.isActive()) {
+				throw AppException.of(SlackErrorCode.SLACK_USER_ALREADY_LINKED);
+			}
+		});
+
+		link.updateSlackUserId(res.user().id());
+		link.activate(); // 갱신 시 비활성 상태였다면 재활성
+		return SlackUserLinkRes.from(slackUserLinkRepository.save(link));
 	}
 }


### PR DESCRIPTION
<!-- 제목 -->
[feat] Slack 연동 갱신, 조회, 연동 해제 기능 추가


<!-- 템플릿 내용 -->
#8 

### 변경사항
- SlackUserLink 갱신 API(`PUT /slack/links/{userId}`) 추가
- SlackUserLink 조회 API(`GET /slack/links/{userId}`) 추가
- SlackUserLink 연동 해제 API(`DELETE /slack/links/{userId}`) 추가
